### PR TITLE
Check that submitted token is not undefined or an empty string.

### DIFF
--- a/src/components/ShareList.js
+++ b/src/components/ShareList.js
@@ -8,6 +8,11 @@ const ShareList = props => {
 
   const handleSubmit = event => {
     event.preventDefault();
+    if (tokenToCheck === undefined || tokenToCheck === '') {
+      toggleError(true);
+      return;
+    }
+
     toggleError(false);
     verifySharedToken(tokenToCheck);
   };


### PR DESCRIPTION
## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   ✓  | :bug: Bug fix              |
|     | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Description

@SaraSweetie discovered a bug in the ShareList component. When trying to join/share a shopping list token, if a user clicked submit without entering anything the token passed in for verification was `undefined`. The user would not be notified that there was a problem. With the browser dev tools open the app would crash. Error messages are in the image below.

This fix checks that the token passed in for verification is neither `undefined` nor an empty string.

### Before

![Screen Shot 2020-05-20 at 1 13 55 PM](https://user-images.githubusercontent.com/7929227/82493335-a3172480-9a9c-11ea-8aba-22b6531b58f9.png)


### After

![Screen Shot 2020-05-20 at 1 14 25 PM](https://user-images.githubusercontent.com/7929227/82493357-ab6f5f80-9a9c-11ea-86c7-e5a3e7141364.png)


## Acceptance Criteria

Entering any invalid token, including clicking on the submit button without entering a token, returns an error message to try again or create a new list.

Entering a valid token takes the user to the associated shopping list.

## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

View this deployed branch [here](https://deploy-preview-43--tcl-6-smart-shopping-list.netlify.app/).
If you already have a token in localStorage, delete it and refresh your browser.
Try entering nothing and clicking submit.
Try entering anything and clicking submit.
Only valid tokens should succeed. Otherwise you will receive an error message.
