### PR TITLE
error message for empty entry and only spaces

### DIFF
--- a/src/components/AddItemForm.js
+++ b/src/components/AddItemForm.js
@@ -13,6 +13,7 @@ class AddItemForm extends React.Component {
       last_purchased: '',
       number_purchases: 0,
       hasDupe: false,
+      invalid: false,
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleSchedule = this.handleSchedule.bind(this);
@@ -23,6 +24,7 @@ class AddItemForm extends React.Component {
     this.setState({
       name: event.target.value,
       hasDupe: false,
+      invalid: false,
     });
   }
 
@@ -44,6 +46,13 @@ class AddItemForm extends React.Component {
     const hasDupe = props.list.some(
       item => item.name_normalized === name_normalized,
     );
+
+    const invalid = name_normalized.length > 0;
+
+    if (!invalid) {
+      this.setState({ invalid: true });
+      return;
+    }
 
     if (hasDupe) {
       this.setState({ hasDupe });
@@ -101,10 +110,11 @@ class AddItemForm extends React.Component {
           <br />
           <input className="submit-btn" type="submit" value="Submit" />
           {this.state.hasDupe && (
-            <p>
+            <p className="error">
               {this.state.name} has already been added to your shopping list.
             </p>
           )}
+          {this.state.invalid && <p className="error">Invalid item name.</p>}
         </form>
         <Nav />
       </>


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._ 

## Description

Bug fix: Users were able to enter spaces as an item name. Users were also able to click the submit button without entering any characters. This bug is now fixed and displays an error message.

## Related Issue

Part of issue #19 
<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

Fix the bug.

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓ | :bug: Bug fix              |
|    | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### After
Error message when spaces entered for the item name. The error message also appears when just the submit button is clicked without entering any characters.
<img width="1017" alt="Screen Shot 2020-05-27 at 8 54 57 AM" src="https://user-images.githubusercontent.com/33433415/83022017-e3c0f180-9ff8-11ea-9325-ec67109f00d5.png">


## Testing Steps / QA Criteria
branch `sara-input-space-bug`

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

